### PR TITLE
changes examples to use port 8080

### DIFF
--- a/01-py-flask-hello/Dockerfile
+++ b/01-py-flask-hello/Dockerfile
@@ -7,8 +7,8 @@ COPY requirements.txt /app/requirements.txt
 RUN pip install --no-cache-dir --upgrade -r /app/requirements.txt
 
 COPY ./app /app
-EXPOSE 80
+EXPOSE 8080
 
 ENV FLASK_ENV="development" FLASK_APP="jetpack_main"
 
-CMD ["flask", "run", "--host", "0.0.0.0", "--port", "80"]
+CMD ["flask", "run", "--host", "0.0.0.0", "--port", "8080"]

--- a/02-py-flask-hello-buildpack/Procfile
+++ b/02-py-flask-hello-buildpack/Procfile
@@ -1,2 +1,2 @@
-web: flask run --host 0.0.0.0 --port 80
+web: flask run --host 0.0.0.0 --port 8080
 jetpack: jetpack

--- a/03-py-async-jobs/Dockerfile
+++ b/03-py-async-jobs/Dockerfile
@@ -7,6 +7,6 @@ COPY requirements.txt /app/requirements.txt
 RUN pip install --no-cache-dir --upgrade -r /app/requirements.txt
 
 COPY ./app /app
-EXPOSE 80
+EXPOSE 8080
 
-CMD ["uvicorn", "jetpack_main:app", "--host", "0.0.0.0", "--port", "80"]
+CMD ["uvicorn", "jetpack_main:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/04-py-permanent-job/Dockerfile
+++ b/04-py-permanent-job/Dockerfile
@@ -9,6 +9,6 @@ COPY requirements.txt /app/requirements.txt
 RUN pip install --no-cache-dir --upgrade -r /app/requirements.txt 
 
 COPY ./app /app
-EXPOSE 80
+EXPOSE 8080
 
 CMD ["python", "jetpack_main.py"]

--- a/06-py-s3-access/Dockerfile
+++ b/06-py-s3-access/Dockerfile
@@ -7,6 +7,6 @@ COPY requirements.txt /app/requirements.txt
 RUN pip install --no-cache-dir --upgrade -r /app/requirements.txt
 
 COPY ./app /app
-EXPOSE 80
+EXPOSE 8080
 
-CMD ["uvicorn", "jetpack_main:app", "--host", "0.0.0.0", "--port", "80"]
+CMD ["uvicorn", "jetpack_main:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/07-py-cron-job/Dockerfile
+++ b/07-py-cron-job/Dockerfile
@@ -7,6 +7,6 @@ COPY requirements.txt /app/requirements.txt
 RUN pip install --no-cache-dir --upgrade -r /app/requirements.txt
 
 COPY ./app /app
-EXPOSE 80
+EXPOSE 8080
 
 RUN ["echo", "Cron Job Launched"]

--- a/08-py-scheduled-jobs/Dockerfile
+++ b/08-py-scheduled-jobs/Dockerfile
@@ -8,6 +8,6 @@ RUN pip install --no-cache-dir --upgrade -r /app/requirements.txt
 ENV SLACK_URL=https://hooks.slack.com/services/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
 
 COPY ./app /app
-EXPOSE 80
+EXPOSE 8080
 
-CMD ["uvicorn", "jetpack_main:app", "--host", "0.0.0.0", "--port", "80"]oth
+CMD ["uvicorn", "jetpack_main:app", "--host", "0.0.0.0", "--port", "8080"]


### PR DESCRIPTION
This amends each example to use port 8080.

Together with https://github.com/jetpack-io/axiom/pull/1411, I tested the changes here for examples `01-py-flask-hello` and `02-py-flask-hello-buildpack`, and **not** for the rest. I assume they work similarly.